### PR TITLE
Fix log options and error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Python interface to Cadence Spectre.
 
 ## Dependencies and Requirements
 
-- Python 3.9
+- Python >= 3.9
 - [pynut](https://github.com/augustunderground/pynut).
 - [Cadence Spectre](https://www.cadence.com/en_US/home/tools/custom-ic-analog-rf-design/circuit-simulation/spectre-simulation-platform.html), the `spectre` command should be available in you shell
 

--- a/pyspectre/functional.py
+++ b/pyspectre/functional.py
@@ -157,19 +157,18 @@ def simulate(netlist_path: str, includes: Optional[List[str]] = [], raw_path: st
     net = os.path.expanduser(netlist_path)
     inc = [f'-I{os.path.expanduser(i)}' for i in includes] if includes else []
     raw = raw_path or raw_tmp(net)
-    log = f'{net}.log' if not log_path else f'{log_path}'
     if log_path and log_silent:
-        log_option = f'=log {log_path}'
+        log_option = ['=log', log_path]
     elif log_path and not log_silent:
-        log_option = f'+log {log_path}'
+        log_option = ['+log', log_path]
     elif (not log_path) and (not log_silent):
-        log_option = '-log'
+        log_option = ['-log']
     else:
-        buf = log_fifo(log)
-        log_option = f'=log {buf}'
+        buf = log_fifo(f'{net}')
+        log_option = ['=log', buf]
 
     cmd = ['spectre', '-64', '-format', 'nutbin', '-raw', f'{raw}'
-           ] + [log_option] + inc + [net]
+           ] + log_option + inc + [net]
 
     if not os.path.isfile(net):
         raise (FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), net))
@@ -343,7 +342,7 @@ def start_session(net_path: Union[str, Path], includes: Union[list[str], None] =
         = setup_command(config_path)
 
     args = ([spectre_executable] + [net.as_posix()]
-            + inc + ['-raw', raw.as_posix(), f'=log {log}']
+            + inc + ['-raw', raw.as_posix(), '=log', log]
             + spectre_args + additional_spectre_args)
 
     if not net.is_file():

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open('requirements.txt', 'r') as req:
 
 setup(
     name=package_name,
-    version='0.1.0',
+    version='0.1.1',
     author='Yannick Uhlmann',
     author_email='augustunderground@pm.me',
     description='Spectre Interface for Python',


### PR DESCRIPTION
This pull request addresses the following issues:

1. Call to spectre fails, because log option and log path are passed as a single string.
2. Handling of non-zero exit codes (line 183-189) is never executed. Error messages from spectre are not shown.