### PR TITLE
fix function name in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ includes = ['path/to/pdk/libs']
 session  = ps.start_session(netlist, includes)
 
 # Retrieve simulation analyses defined in the netlist
-analyses = ps.get_analyses(session)
+analyses = ps.list_analyses(session)
 
 # Get values for parameters defined in the netlist
 params   = ps.get_parameters(session, ['Wcm2', 'Ld'])


### PR DESCRIPTION
The example in the README contains a legacy function call. Update to the current version.